### PR TITLE
Fix a bug that RecordAggregator.js inserts invalid EHK fields

### DIFF
--- a/node/node_modules/aws-kinesis-agg/RecordAggregator.js
+++ b/node/node_modules/aws-kinesis-agg/RecordAggregator.js
@@ -144,8 +144,9 @@ function aggregate(records, callback) {
 						partitionKeyCount += 1;
 					}
 
-					if (!explicitHashKeyTable
-							.hasOwnProperty(record.ExplicitHashKey)) {
+					if (record.ExplicitHashKey
+							&& !explicitHashKeyTable
+								.hasOwnProperty(record.ExplicitHashKey)) {
 						explicitHashKeyTable[record.ExplicitHashKey] = explicitHashKeyCount;
 						explicitHashKeyCount += 1;
 					}


### PR DESCRIPTION
When input record has no EHK, the `function aggregate()` makes invalid data such as:

```
> explicitHashKeyTable
{ undefined: 0 }
```

It causes deaggregation error and mismatch of calculated buffer size.