### PR TITLE
fix version for build

### DIFF
--- a/java/KinesisLambdaForwarder/pom.xml
+++ b/java/KinesisLambdaForwarder/pom.xml
@@ -59,12 +59,12 @@
         <dependency>
             <groupId>com.amazonaws.services.kinesis</groupId>
             <artifactId>KinesisDeaggregator</artifactId>
-            <version>1.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws.services.kinesis</groupId>
             <artifactId>KinesisAggregator</artifactId>
-            <version>1.0</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/java/KinesisTestConsumers/pom.xml
+++ b/java/KinesisTestConsumers/pom.xml
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>com.amazonaws.services.kinesis</groupId>
 			<artifactId>KinesisDeaggregator</artifactId>
-			<version>1.0</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/java/KinesisTestProducers/pom.xml
+++ b/java/KinesisTestProducers/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>com.amazonaws.services.kinesis</groupId>
 			<artifactId>KinesisAggregator</artifactId>
-			<version>1.0</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
The versions in poms were hardcoded so you could not build. These small fixes to pom enable build when cloning