### PR TITLE
Fix for createExplicitHashKey

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -2,3 +2,6 @@ target
 .settings
 *.prefs
 *.class
+
+.idea/
+*.iml

--- a/java/KinesisAggregator/pom.xml
+++ b/java/KinesisAggregator/pom.xml
@@ -17,6 +17,23 @@
 	<dependencies>
 		<!-- Even though we're a producer, not a consumer, this dependency gives us access to the
 		generated Google protocol buffer classes. -->
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.10</version>
+			<scope>test</scope>
+		</dependency>
+
+
+
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-kinesis-client</artifactId>

--- a/java/KinesisAggregator/src/main/java/com/amazonaws/kinesis/agg/AggRecord.java
+++ b/java/KinesisAggregator/src/main/java/com/amazonaws/kinesis/agg/AggRecord.java
@@ -478,9 +478,9 @@ public class AggRecord {
 		byte[] pkDigest = this.md5.digest(partitionKey.getBytes(StandardCharsets.UTF_8));
 
 		for (int i = 0; i < this.md5.getDigestLength(); i++) {
-			BigInteger p = new BigInteger(Byte.toString(pkDigest[i]));
-			p.shiftLeft((16 - i - 1) * 8);
-			hashKey = hashKey.add(p);
+			BigInteger p = new BigInteger(String.valueOf((int) pkDigest[i] & 0xFF)); // convert to unsigned integer
+			BigInteger shifted = p.shiftLeft((16 - i - 1) * 8);
+			hashKey = hashKey.add(shifted);
 		}
 
 		return hashKey.toString(10);

--- a/java/KinesisAggregator/src/test/java/com/amazonaws/kinesis/agg/AggRecordTest.java
+++ b/java/KinesisAggregator/src/test/java/com/amazonaws/kinesis/agg/AggRecordTest.java
@@ -1,0 +1,83 @@
+package com.amazonaws.kinesis.agg;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class AggRecordTest {
+
+    private static final BigInteger MAX_VALID_HASHKEY = new BigInteger(StringUtils.repeat("FF", 16), 16);
+
+    private static final BigInteger MIN_VALID_HASHKEY = BigInteger.ZERO;
+
+    @Parameterized.Parameters
+    public static Collection<Object> data() {
+        return Arrays.asList(new Object[]{
+                        "abcd",
+                        "LBpUxDst3pfL2wFS0WMh" +
+                                "4HVTvxhD04WbZdKFkJyQ" +
+                                "xmqlIDgoqj18g6kODL57" +
+                                "cUHYk6EAk8hGwyuBMzJ1" +
+                                "02rRthyGdWgw5iyiOLu6" +
+                                "Gihs47AEEChW7KBIcTR8" +
+                                "CzI7tY9QOuY5rV0SlPN3" +
+                                "sl9GxIeVNi6y8FT0PrWW" +
+                                "R05a2rMK81PFGYIYlviS" +
+                                "XgJDolOiH13Zh3JiTmtA" +
+                                "2jJMhdDx1Tab3Gr3itWq" +
+                                "8kg6UavBBgAUtCnQUxhV" +
+                                "patNMrl28W0dKaqZ",
+                        new String(new byte[]{
+                                66,
+                                69,
+                                84,
+                                0,
+                                0,
+                                0,
+                                0,
+                                46,
+                                69,
+                                -17,
+                                -65,
+                                -67,
+                                -17,
+                                -65,
+                                -67
+                        })
+                }
+        );
+    }
+
+    private final String partitionKey;
+
+    public AggRecordTest(final String partitionKey) {
+        this.partitionKey = partitionKey;
+    }
+
+    @Test
+    public void shouldGenerateValidHashKeys() {
+        final String expectedHashKeyHex = DigestUtils.md5Hex(partitionKey);
+        final String expectedHashKeyDecimal = new BigInteger(expectedHashKeyHex, 16).toString(10);
+
+        final AggRecord record = new AggRecord();
+        record.addUserRecord(partitionKey, null, "dummy data".getBytes());
+
+        assertThat(new BigInteger(expectedHashKeyDecimal).compareTo(MIN_VALID_HASHKEY) >= 0, is(true));
+
+        assertThat(new BigInteger(expectedHashKeyDecimal).compareTo(MAX_VALID_HASHKEY) <= 0, is(true));
+
+        assertThat(record.getExplicitHashKey(), equalTo(expectedHashKeyDecimal));
+    }
+
+}


### PR DESCRIPTION
After checking the C++ source code and comparing it to the fix I had provided in #29, looks like the fix was indeed correct:

```java
	private String createExplicitHashKey(final String partitionKey) {
		BigInteger hashKey = BigInteger.ZERO;

		this.md5.reset();
		byte[] pkDigest = this.md5.digest(partitionKey.getBytes(StandardCharsets.UTF_8));

		for (int i = 0; i < this.md5.getDigestLength(); i++) {
			BigInteger p = new BigInteger(String.valueOf((int) pkDigest[i] & 0xFF)); // convert to unsigned integer
			BigInteger shifted = p.shiftLeft((16 - i - 1) * 8);
			hashKey = hashKey.add(shifted);
		}

		return hashKey.toString(10);
	}
```

This PR is accompanied with some unit tests to prevent future regression.

Fixes #29.