### PR TITLE
Specify underscore dependency in package.json

### DIFF
--- a/node/node_modules/aws-kinesis-agg/package.json
+++ b/node/node_modules/aws-kinesis-agg/package.json
@@ -8,7 +8,8 @@
         "email": "meyersi@amazon.com"
     },
     "dependencies": {
-        "protobufjs": "5.0.1"
+        "protobufjs": "5.0.1",
+        "underscore": "1.8.3"
     },
     "keywords": [
         "amazon",


### PR DESCRIPTION
Right now RecordAggregator.js has a dependency on `underscore` which isn't listed in `package.json`.

This adds the dependency so it is installed automatically along with `aws-kinesis-agg`.