### PR TITLE
add missing dev dependencies so we can run the test suite

### DIFF
--- a/node/node_modules/aws-kinesis-agg/package.json
+++ b/node/node_modules/aws-kinesis-agg/package.json
@@ -11,6 +11,10 @@
         "protobufjs": "5.0.1",
         "underscore": "1.8.3"
     },
+    "devDependencies": {
+        "should": "^13.2.1",
+        "node-uuid": "1.4.8"
+    },
     "keywords": [
         "amazon",
         "kinesis",


### PR DESCRIPTION
There is a modest test suite for the `node` implementation at `kinesis-aggregation/node/node_modules/aws-kinesis-agg/test`. However, none of the tests can be run as they require modules that are not accounted for in the overall module's (dev) dependencies. This PR adds those so the individual tests can be run.