### PR TITLE
(node) don't spuriously add ExplicitHashKey values to user records

### DIFF
--- a/node/node_modules/aws-kinesis-agg/RecordAggregator.js
+++ b/node/node_modules/aws-kinesis-agg/RecordAggregator.js
@@ -86,11 +86,14 @@ function flush(records, onReadyCallback) {
 		} else {
 
 			// call the provided callback
-			onReadyCallback(undefined, {
+			var aggregated = {
 				PartitionKey : pk,
-				ExplicitHashKey : ehk,
 				Data : aggRecord
-			});
+			};
+			if(ehk !== undefined) {
+				aggregated["ExplicitHashKey"] = ehk;
+			}
+			onReadyCallback(undefined, aggregated);
 		}
 	});
 };
@@ -151,15 +154,18 @@ function aggregate(records, callback) {
 						explicitHashKeyCount += 1;
 					}
 
+					var aggRecord = {
+						"partition_key_index" : partitionKeyTable[record.PartitionKey],
+						data : record.Data,
+						tags : []
+					};
+
+					if(record.ExplicitHashKey) {
+						aggRecord["explicit_hash_key_index"] = explicitHashKeyTable[record.ExplicitHashKey];
+					}
 					// add the AggregatedRecord object with partition and hash
 					// key indexes
-					putRecords
-							.push({
-								"partition_key_index" : partitionKeyTable[record.PartitionKey],
-								"explicit_hash_key_index" : explicitHashKeyTable[record.ExplicitHashKey],
-								data : record.Data,
-								tags : []
-							});
+					putRecords.push(aggRecord);
 				});
 
 		// encode the data

--- a/node/node_modules/aws-kinesis-agg/test/testOptionalExplicitHashKey.js
+++ b/node/node_modules/aws-kinesis-agg/test/testOptionalExplicitHashKey.js
@@ -1,0 +1,72 @@
+/*
+		Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+
+        http://aws.amazon.com/asl/
+
+    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+var crypto = require('crypto');
+var uuid = require('node-uuid');
+var RecordAggregator = require('../RecordAggregator');
+
+var generateUserRecordsWithoutEHKs = function() {
+    var records = [];
+    for (var i = 0; i < 100; i++) {
+        var u = uuid.v4();
+        var record = {
+            PartitionKey : u,
+            // random payload
+            Data : new Buffer(crypto.randomBytes(100).toString('base64'))
+        };
+    
+        records.push(record);
+    }
+    return records;
+};
+
+var generateUserRecordsWithEHKs = function() {
+    return generateUserRecordsWithoutEHKs()
+        .map(function(record, index) {
+            record.ExplicitHashKey = index;
+            return record;
+        });
+};
+
+var runTest = function(records, assertion) {
+    var agg = new RecordAggregator();
+    agg.aggregateRecords(records, false, null, null);
+    agg.flushBufferedRecords(function(error, aggregated) {
+        //console.log(aggregated);
+        console.log(assertion(aggregated) ? 'Ok' : 'Failed');
+        //console.log(('ExplicitHashKey' in aggregated) ? 'Failed' : 'Ok');
+    });
+};
+
+runTest(generateUserRecordsWithoutEHKs(), function(aggregated) {
+    return !('ExplicitHashKey' in aggregated);
+});
+
+runTest(generateUserRecordsWithEHKs(), function(aggregated) {
+    //console.log(aggregated)
+    return ('ExplicitHashKey' in aggregated);
+});
+
+// var agg = new RecordAggregator();
+// var records = generateUserRecordsWithoutEHKs();
+
+// agg.aggregateRecords(records, false, null, null);
+// agg.flushBufferedRecords(function(error, aggregated) {
+//     console.log(aggregated)
+//     console.log(('ExplicitHashKey' in aggregated) ? 'Failed' : 'Ok');
+// });
+
+// var agg = new RecordAggregator();
+// records = generateUserRecordsWithEHKs();
+
+// agg.aggregateRecords(records, false, null, null);
+// agg.flushBufferedRecords(function(error, aggregated) {
+//     console.log(('ExplicitHashKey' in aggregated) ? 'Ok' : 'Failed');
+// });


### PR DESCRIPTION
This fixes issue #48 and includes a new test demonstrating the fix.

Note that this PR requires changes (specifically the dev dependencies) in PR #46.