### PR TITLE
Fix production dependencies and npm project name

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "aws-kinesis-agg-fix",
+    "name": "aws-kinesis-agg",
     "description": "Node.js module to simplify working with Amazon Kinesis Records using Protcol Buffers encoding",
     "version": "4.0.2",
     "homepage": "http://github.com/awslabs/kinesis-aggregation",
@@ -8,8 +8,8 @@
         "email": "meyersi@amazon.com"
     },
     "dependencies": {
-        "async": "^2.6.0",
-        "jshint": "^2.9.6",
+        "async": "2.6.1",
+        "jshint": "2.9.7",
         "protobufjs": "5.0.3"
     },
     "keywords": [


### PR DESCRIPTION
Issue 58

The current NPM release is version 4.0.2 package name aws-kinesis-agg-fix, however the documentation for that package https://www.npmjs.com/package/aws-kinesis-agg-fix indicates that it should be imported as

```
var agg = require('aws-kinesis-agg');
```

I've created this PR to correct this.
