### PR TITLE
fix syntax error 'throw' instead of raise

### DIFF
--- a/node/lib/kpl-agg.js
+++ b/node/lib/kpl-agg.js
@@ -21,8 +21,7 @@ const KINESIS_MAX_PAYLOAD_BYTES = (1024 * 1024) - 16 - Buffer.byteLength(common.
 
 function calculateVarIntSize(value) {
 	if (value < 0) {
-		raise
-		Error("Size values should not be negative.");
+		throw new Error("Size values should not be negative.");
 	} else if (value == 0) {
 		return 1;
 	}


### PR DESCRIPTION
HI,
*Description of changes:*
Fixing a  syntax error,  'raise' is used instead of 'throw'