### PR TITLE
NodeJS library fixes and additions

### DIFF
--- a/node/lib/kpl-agg.js
+++ b/node/lib/kpl-agg.js
@@ -21,8 +21,7 @@ const KINESIS_MAX_PAYLOAD_BYTES = (1024 * 1024) - 16 - Buffer.byteLength(common.
 
 function calculateVarIntSize(value) {
 	if (value < 0) {
-		raise
-		Error("Size values should not be negative.");
+		throw new Error("Size values should not be negative.");
 	} else if (value == 0) {
 		return 1;
 	}

--- a/node/lib/kpl-agg.js
+++ b/node/lib/kpl-agg.js
@@ -281,6 +281,16 @@ RecordAggregator.prototype.flushBufferedRecords = function (onReadyCallback) {
 };
 
 /**
+ * Method to build an encoded record of all inflight records, flushes
+ * the current inflight records after getting called.
+ */
+RecordAggregator.prototype.build = function(){
+	const data= generateEncodedRecord(this.putRecords);
+	this.clearRecords();
+	return data;
+}
+
+/**
  * Method to return the length of inflight records.
  */
 RecordAggregator.prototype.length = function(){

--- a/node/lib/kpl-agg.js
+++ b/node/lib/kpl-agg.js
@@ -281,6 +281,15 @@ RecordAggregator.prototype.flushBufferedRecords = function (onReadyCallback) {
 };
 
 /**
+ * Method to calculate a record size without adding it to the inflight records.
+ * @param {*} record record to check
+ */
+RecordAggregator.prototype.calculateUserRecordSize = function(record){
+	validateRecord(record);
+	return calculateRecordSize(this, record)
+}
+
+/**
  * method to add a record to inflight records.
  * @param {*} record record to add
  */

--- a/node/lib/kpl-agg.js
+++ b/node/lib/kpl-agg.js
@@ -232,7 +232,7 @@ function RecordAggregator(onReadyCallback) {
 	this.onReadyCallback = onReadyCallback;
 
 };
-module.exports = RecordAggregator;
+module.exports.RecordAggregator = RecordAggregator;
 
 /**
  * Set onReadyCallback

--- a/node/lib/kpl-agg.js
+++ b/node/lib/kpl-agg.js
@@ -281,6 +281,13 @@ RecordAggregator.prototype.flushBufferedRecords = function (onReadyCallback) {
 };
 
 /**
+ * Method to return the length of inflight records.
+ */
+RecordAggregator.prototype.length = function(){
+	return this.putRecords.length;
+}
+
+/**
  * Method to check if a specific record will fit in the inflight records array (1 MB max)
  * @param {*} record record to check
  */

--- a/node/lib/kpl-agg.js
+++ b/node/lib/kpl-agg.js
@@ -281,6 +281,14 @@ RecordAggregator.prototype.flushBufferedRecords = function (onReadyCallback) {
 };
 
 /**
+ * Method to check if a specific record will fit in the inflight records array (1 MB max)
+ * @param {*} record record to check
+ */
+RecordAggregator.prototype.checkIfUserRecordFits = function(record){
+	return !((this.totalBytes + this.calculateUserRecordSize(record)) > KINESIS_MAX_PAYLOAD_BYTES);
+}
+
+/**
  * Method to calculate a record size without adding it to the inflight records.
  * @param {*} record record to check
  */


### PR DESCRIPTION
Hi there,

 I'm building a port of KPL's functionality in nodeJS  [node-kpl](https://github.com/jodevsa/node-kinesis-producer) and decided to use this library for the aggregation part, unfortunately i had some problems and limitations that this PR might address:
- fixes:

1.  RecordAggregator wasn't public due to a typo
2. Fix typo in throw error snytax

- new methods:

```
RecordAggregator.length()
RecordAggregator.addUserRecord() // add a single record
RecordAggregator.build()  // a synchronous method that flushes the inflight records and returns an encoded record
RecordAggregator.checkifUserRecordFits() ) // useful to know if a record I'm holding will fit with the rest of inflight records before adding it.
RecordAggregator.calculateUserRecordSize() // useful to know the the size of a record before adding it.

```

Thanks
