### PR TITLE
Fixed the Kinesis Analytics deaggregation to make sure the recordId gets passed back to the output of the deaggregation function with the record.

### DIFF
--- a/python/aws_kinesis_agg.egg-info/PKG-INFO
+++ b/python/aws_kinesis_agg.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: aws-kinesis-agg
-Version: 1.1.1
+Version: 1.1.3
 Summary: Python module to assist in taking advantage of the Kinesis message aggregation format for both aggregation and deaggregation.
 Home-page: http://github.com/awslabs/kinesis-aggregation
 Author: Brent Nash

--- a/python/aws_kinesis_agg/deaggregator.py
+++ b/python/aws_kinesis_agg/deaggregator.py
@@ -61,6 +61,9 @@ def _create_user_record(ehks, pks, mr, r, sub_seq_num):
         if key != 'kinesis' and key != 'data':
             new_record[key] = value
 
+    if 'recordId' in r['kinesis']:
+        new_record['kinesis']['recordId'] = r['kinesis']['recordId']
+
     return new_record
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -21,7 +21,7 @@ with open('README.md', encoding='utf-8') as f:
 setup(
   name='aws_kinesis_agg',
   packages=['aws_kinesis_agg'],
-  version='1.1.1',
+  version='1.1.3',
   description='Python module to assist in taking advantage of the Kinesis message aggregation '
               'format for both aggregation and deaggregation.',
   long_description=long_description,

--- a/python/test/test_deagg.py
+++ b/python/test/test_deagg.py
@@ -211,22 +211,26 @@ class RecordDeaggregatorTest(unittest.TestCase):
            {
              'explicitHashKey': '339606600942967391854603552402021847292',
              'partitionKey': '1562602074896',
-             'data': 'RECORD 2005 pjqrcfbxafzdndzmbgane'
+             'data': 'RECORD 2005 pjqrcfbxafzdndzmbgane',
+             'recordId': '49597411459012285111935017621194032819223185658889633794'
            },
            {
              'explicitHashKey': '339606600942967391854603552402021847292',
              'partitionKey': '1562602074896',
-             'data': 'RECORD 2006 pjqrcfbxafzdndzmbgane'
+             'data': 'RECORD 2006 pjqrcfbxafzdndzmbgane',
+             'recordId': '49597411459012285111935017621194032819223185658889633794'
            },
            {
              'explicitHashKey': '339606600942967391854603552402021847292',
              'partitionKey': '1562602074896',
-             'data': 'RECORD 2007 pjqrcfbxafzdndzmbgane'
+             'data': 'RECORD 2007 pjqrcfbxafzdndzmbgane',
+             'recordId': '49597411459012285111935017621194032819223185658889633794'
            },
            {
              'explicitHashKey': '339606600942967391854603552402021847292',
              'partitionKey': '1562602074896',
-             'data': 'RECORD 2008 pjqrcfbxafzdndzmbgane'
+             'data': 'RECORD 2008 pjqrcfbxafzdndzmbgane',
+             'recordId': '49597411459012285111935017621194032819223185658889633794'
            }
         ]
 
@@ -247,6 +251,9 @@ class RecordDeaggregatorTest(unittest.TestCase):
             self.assertEqual(generated_record['kinesis']['explicitHashKey'], actual_record['explicitHashKey'],
                              'Actual and generated explicit hash keys do not match for record %d' % i)
 
+            self.assertEqual(generated_record['kinesis']['recordId'], actual_record['recordId'],
+                             'Actual and generated recordIds keys do not match for record %d' % i)
+
             decoded_data = base64.b64decode(generated_record['kinesis']['data']).decode('utf-8')
             actual_data = actual_record['data']
 
@@ -259,7 +266,8 @@ class RecordDeaggregatorTest(unittest.TestCase):
         actual_user_records = [
            {
              'partitionKey': '1562602074896',
-             'data': 'RECORD 749 pjqrcfbxafzdndzmbgane'
+             'data': 'RECORD 749 pjqrcfbxafzdndzmbgane',
+             'recordId': '49597411459012285111935017620416693517210978893395132418'
            }
         ]
 
@@ -276,6 +284,9 @@ class RecordDeaggregatorTest(unittest.TestCase):
 
             self.assertEqual(generated_record['kinesis']['partitionKey'], actual_record['partitionKey'],
                              'Actual and generated partition keys do not match for record %d.' % i)
+
+            self.assertEqual(generated_record['kinesis']['recordId'], actual_record['recordId'],
+                             'Actual and generated recordIds keys do not match for record %d' % i)
 
             decoded_data = base64.b64decode(generated_record['kinesis']['data']).decode('utf-8')
             actual_data = actual_record['data']


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed the Kinesis Analytics deaggregation to make sure the recordId gets passed back to the output of the deaggregation function with the record.

@IanMeyers Hopefully this will be the last PR.  Thanks again for all the help with this and let me know if you have any questions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
