### PR TITLE
Fix python 2.7 build

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -13,6 +13,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from io import open
 from setuptools import setup
 
 with open('README.md', encoding='utf-8') as f:


### PR DESCRIPTION
*Description of changes:*

The 'encoding' kwarg of the built-in open is not available in Python 2.
The python 2.6/2.7 implementation of `io.open` is pure python and slow, but that's not a concern here.
Its python 3 implementation is just an alias of the built-in open.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
