### PR TITLE
Fixing syntax error

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -29,6 +29,6 @@ declare module 'aws-kinesis-agg' {
         encodedRecordHandler: (encodedRecord: EncodedRecord, callback: (err?: Error, data?: Kinesis.Types.PutRecordOutput) => void) => void,
         afterPutAggregatedRecords: () => void, 
         errorCallback: (error: Error, data?: EncodedRecord) => void,
-        queueSize: number = 1
+        queueSize: number
     ): void;
 }


### PR DESCRIPTION
node_modules/aws-kinesis-agg/index.d.ts(32,9):
error TS2371: A parameter initializer is only allowed
in a function or constructor implementation.

