### PR TITLE
Fix syntax error in TypeScript declarations

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -29,6 +29,6 @@ declare module 'aws-kinesis-agg' {
         encodedRecordHandler: (encodedRecord: EncodedRecord, callback: (err?: Error, data?: Kinesis.Types.PutRecordOutput) => void) => void,
         afterPutAggregatedRecords: () => void, 
         errorCallback: (error: Error, data?: EncodedRecord) => void,
-        queueSize: number = 1
+        queueSize?: number
     ): void;
 }


### PR DESCRIPTION
This is blocking TypeScript compilation because the type declarations have a syntax error.

*Issue #, if available:*

Fixes #80.  (code changes in #80 are slightly incorrect)

*Description of changes:*

TypeScript declarations must be types onto, not implementation.

Default values are considered "implementation" because the default value is a runtime expression.
Fix is to encode the corresponding type info instead: it's of type `number` and is optional

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.