### PR TITLE
fix: invalid UserRecord.data type

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -6,7 +6,7 @@ declare module 'aws-kinesis-agg' {
         explicitPartitionKey: string;
         sequencenumber: string;
         subSequencenumber: number;
-        data: Buffer;
+        data: string;
     }
 
     export interface EncodedRecord {


### PR DESCRIPTION
UserRecord.data type is string and not Buffer as can be seen in https://github.com/awslabs/kinesis-aggregation/blob/master/node/lib/kpl-deagg.js#L97 and https://github.com/awslabs/kinesis-aggregation/blob/master/node/lib/kpl-deagg.js#L136