### PR TITLE
Fix deaggregator_test.go to use `fmt.Sprint` to prevent a `vet` error.

### DIFF
--- a/go/deaggregator/deaggregator_test.go
+++ b/go/deaggregator/deaggregator_test.go
@@ -40,7 +40,7 @@ func generateAggregateRecord(numRecords int) []byte {
 		}
 
 		aggr.Records = append(aggr.Records, r)
-		partKeyVal := "test" + string(i)
+		partKeyVal := "test" + fmt.Sprint(i)
 		partKeyTable = append(partKeyTable, partKeyVal)
 	}
 


### PR DESCRIPTION
Go 1.15 [introduced a warning](https://golang.org/doc/go1.15#vet) during `vet` that causes the following error:

```
$ go vet ./...
deaggregator/deaggregator_test.go:43:26: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```

This commit fixes the test to use `fmt.Sprint()` as indicated.

*Issue #, if available:*
n/a
*Description of changes:*
Fix `go vet` error as per above

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
