### PR TITLE
import Mapping from collections.abc

### DIFF
--- a/python/aws_kinesis_agg/deaggregator.py
+++ b/python/aws_kinesis_agg/deaggregator.py
@@ -176,7 +176,7 @@ def iter_deaggregate_records(records):
     return value - Each yield returns a single Kinesis user record. (dict)"""
     
     # We got a single record...try to coerce it to a list
-    if isinstance(records, collections.Mapping):
+    if isinstance(records, collections.abc.Mapping):
         records = [records]
         
     for r in records:


### PR DESCRIPTION
    DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
