### PR TITLE
Fix node typings

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -1,4 +1,5 @@
 import {Kinesis} from 'aws-sdk';
+import {KinesisStreamRecordPayload} from 'aws-lambda/trigger/kinesis-stream';
 
 declare module 'aws-kinesis-agg' {
     export interface UserRecord {
@@ -14,13 +15,13 @@ declare module 'aws-kinesis-agg' {
         data: Buffer;
     }
 
-    export function deaggregate(kinesisRecord: Kinesis.Types.Record, 
+    export function deaggregate(kinesisRecord: KinesisStreamRecordPayload, 
         computeChecksums: boolean,
         perRecordCallback: (err: Error, userRecords?: UserRecord) => void,
         afterRecordCallback: (err?: Error, errorUserRecord?: UserRecord) => void
     ): void;
 
-    export function deaggregateSync(kinesisRecord: Kinesis.Types.Record, 
+    export function deaggregateSync(kinesisRecord: KinesisStreamRecordPayload, 
         computeChecksums: boolean,
         afterRecordCallback: (err: Error, userRecords?: UserRecord[]) => void
     ): void;

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -93,6 +93,12 @@
             "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
             "dev": true
         },
+        "@types/aws-lambda": {
+            "version": "8.10.64",
+            "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.64.tgz",
+            "integrity": "sha512-LRKk2UQCSi7BsO5TlfSI8cTNpOGz+MH6+RXEWtuZmxJficQgxwEYJDiKVirzgyiHce0L0F4CqCVvKTwblAeOUw==",
+            "dev": true
+        },
         "@types/long": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",

--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-kinesis-agg",
     "description": "Node.js module to simplify working with Amazon Kinesis Records using Protcol Buffers encoding",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "homepage": "http://github.com/awslabs/kinesis-aggregation",
     "bugs": {
         "url": "http://github.com/awslabs/kinesis-aggregation",

--- a/node/package.json
+++ b/node/package.json
@@ -44,6 +44,7 @@
         "test": "export NODE_ENV=test && mocha --recursive --timeout 4000"
     },
     "devDependencies": {
+        "@types/aws-lambda": "^8.10.64",
         "aws-sdk": "^2.339.0",
         "jshint": "^2.11.0",
         "mocha": "^8.1.1",

--- a/node/test/testOptionalExplicitHashKey.js
+++ b/node/test/testOptionalExplicitHashKey.js
@@ -17,7 +17,7 @@ const generateUserRecordsWithoutEHKs = function() {
         var record = {
             partitionKey : u,
             // random payload
-            data : new Buffer(crypto.randomBytes(100).toString('base64'))
+            data : Buffer.from(crypto.randomBytes(100).toString('base64'))
         };
     
         records.push(record)


### PR DESCRIPTION
*Issue #, if available:*

This should resolve #104 and resolve #118 

*Description of changes:*

Just use `KinesisStreamRecordPayload` (from `aws-lambda/triggers/kinesis-stream`) instead of `Record` (from `aws-sdk/clients/kinesis`).

`KinesisStreamRecordPayload` has camelCase properties, e.g. `data`, which matches the code in `kpl-deagg.js`:

https://github.com/awslabs/kinesis-aggregation/blob/f9f2a28be83204f2e3c29d38a58bb94a804d7e7c/node/lib/kpl-deagg.js#L39

whereas the current typing of `Record` has PascalCase properties, e.g. `Data`.

The type mismatch prevents TypeScript compiling/transpiling.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
