### PR TITLE
Fix node UserRecord typings

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -5,8 +5,8 @@ declare module 'aws-kinesis-agg' {
     export interface UserRecord {
         partitionKey: string;
         explicitPartitionKey?: string;
-        sequencenumber: string;
-        subSequencenumber: number;
+        sequenceNumber: string;
+        subSequenceNumber: number;
         data: string;
     }
 

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -4,7 +4,7 @@ import {KinesisStreamRecordPayload} from 'aws-lambda/trigger/kinesis-stream';
 declare module 'aws-kinesis-agg' {
     export interface UserRecord {
         partitionKey: string;
-        explicitPartitionKey: string;
+        explicitPartitionKey?: string;
         sequencenumber: string;
         subSequencenumber: number;
         data: string;

--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-kinesis-agg",
     "description": "Node.js module to simplify working with Amazon Kinesis Records using Protcol Buffers encoding",
-    "version": "4.1.3",
+    "version": "4.1.4",
     "homepage": "http://github.com/awslabs/kinesis-aggregation",
     "bugs": {
         "url": "http://github.com/awslabs/kinesis-aggregation",


### PR DESCRIPTION
*Issue #, if available:*

possibly #48 

*Description of changes:*

- change `sequencenumber` to `sequenceNumber`
- change `subSequencenumber` to `subSequencerNumber`
- make `explicitHashKey` optional

*Why?*

`node/lib/kpl-deagg.js` uses camelCase for `sequenceNumber` and `subSequenceNumber`. Currently, the mismatch means that `UserRecord.sequencenumber` and `UserRecord.subSequencenumber` are undefined

The `explicitHashKey` should be optional, because it is not a required parameter of a [PutRecord](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html) nor [PutRecordRequestEntry](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecordsRequestEntry.html). Making it optional in the interface means that expected `UserRecord` with undefined `explicitHashKey` can be used in tests and code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
